### PR TITLE
Fix issue #3

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,9 +1,7 @@
-#
-# ~/.bash_profile
-#
-
 [[ -f ~/.bashrc ]] && . ~/.bashrc
 
-if systemctl -q is-active graphical.target && [[ ! $DISPLAY && $XDG_VTNR -eq 1 ]]; then
+eval $(keychain --clear --eval --agents gpg,ssh --quiet)
+
+if [[ ! $DISPLAY && $XDG_VTNR -eq 1 ]]; then
 	  startx
 fi

--- a/.config/qtile/autostart.sh
+++ b/.config/qtile/autostart.sh
@@ -1,12 +1,20 @@
 #!/bin/sh
 xset -b
+
 setxkbmap -option caps:swapescape
 #setxkbmap -layout us,rs -variant ,alternatequotes -option grp:alt_shift_toggle,caps:swapescape
+
 numlockx &
 dunst &
 udiskie &
+
+#picom &
 compton --backend glx &
+
 feh --bg-fill ~/stuff/pictures/alps-house.jpg
-gpg-agent &
-ssh-agent &
+
+#lxpolkit &
+#gpg-agent &
+#ssh-agent &
+
 mpd &


### PR DESCRIPTION
Closes #3 

It seems that Gnome uses SystemD or something else to set `SSH_AUTH_SOCK` for every spawned program.
So I decided not to use Gnome Keyring. Instead I will put `keychain` program in `.bash_profile`.
It does everything I want it to do expect it isn't in `autostart.sh`, which isn't a big deal.